### PR TITLE
Update standard to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "jest": "^22.4.2",
     "prettier": "^1.13.0",
-    "standard": "^12.0.0"
+    "standard": "^14.1.0"
   },
   "dependencies": {},
   "standard": {


### PR DESCRIPTION
However, I am not sure why Travis has no problem on my repository.
npm test succeeded after I simply changed the version of standard.